### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eagle1 whereis API
+# Eagle1 Whereis API
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/eagle1-sys/whereis-api-v0)
 
 ## Goal


### PR DESCRIPTION
Use "Whereis" instead of "whereis"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project title capitalization from “Eagle1 whereis API” to “Eagle1 Whereis API” to improve consistency and readability across user-facing materials.
  * Clarifies naming in top-level documentation and aligns with style guidelines, reducing confusion in references.
  * No functional, configuration, or API changes; behavior remains the same.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->