### PR TITLE
Makefile: check deno version when 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ update: build ## Build whereis-api docker image and restart api and postgres ser
 	@$(MAKE) status
 
 test: check_docker ## Run 'deno task test' in the api container
+	@echo "=> Checking deno version"
+	@docker exec -it whereis-api-v0 deno --version
 	@echo "=> Running 'deno task test' within api container ..."
 	@docker exec -it whereis-api-v0 deno task test
 


### PR DESCRIPTION
"make test" will return the deno version within the container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a runtime version check that logs the Deno version before executing the test suite, improving traceability and debugging in CI/CD logs.
* **Chores**
  * Enhanced test diagnostics by surfacing environment details from the containerized runtime during test runs.
  * No user-facing functionality changes; this update only affects development and build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->