### PR TITLE
Update PostgreSQL data volume path in docker-compose

### DIFF
--- a/config/docker-compose.yaml.sample
+++ b/config/docker-compose.yaml.sample
@@ -6,7 +6,7 @@ services:
       - 5432:5432
     restart: always
     volumes:
-      - whereis-postgres-data:/var/lib/postgresql/data
+      - whereis-postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_DB: whereis
       POSTGRES_USER: postgres

--- a/config/docker-compose.yaml.sample
+++ b/config/docker-compose.yaml.sample
@@ -1,6 +1,6 @@
 services:
   whereis-postgres:
-    image: postgres
+    image: postgres:18
     container_name: whereis-postgres
     ports:
       - 5432:5432


### PR DESCRIPTION
Due to the latest pgsql server 18.1, it is expecting a new directory path. 

## Background
The suggested container configuration for 18+ is to place a single mount at /var/lib/postgresql which will then place PostgreSQL data in a subdirectory, allowing usage of "pg_upgrade --link" without mount point boundary issues.

See https://github.com/docker-library/postgres/issues/37
      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration for PostgreSQL.
  * Pinned PostgreSQL image to version 18.
  * Changed the container data volume mount path for PostgreSQL to a new directory inside the container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->