### PR TITLE
Bugfix: Query grafana log by env

### DIFF
--- a/src/tools/watcher.ts
+++ b/src/tools/watcher.ts
@@ -172,7 +172,7 @@ async function analyseLog(args: string[]): Promise<void> {
 function getOptionsFromArgs(args: string[]): Record<string, unknown> {
     const result = {
         service: "whereis-api",
-        env: "prod",
+        env: "",
         type: "",
         level: "error",
         start: 0,
@@ -195,6 +195,9 @@ function getOptionsFromArgs(args: string[]): Record<string, unknown> {
 
         if (arg === "--service" && i + 1 < args.length) {
             result.service = args[i + 1];
+            i++;
+        } else if (arg === "--env" && i + 1 < args.length) {
+            result.env = args[i + 1];
             i++;
         } else if (arg === "--type" && i + 1 < args.length) {
             result.type = args[i + 1];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `--env` command-line argument, enabling users to specify the environment for log analysis operations.

* **Changes**
  * Updated default environment configuration behavior for log analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->