### PR TITLE
Refine: Print the commit number and build date at system startup.

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -28,8 +28,8 @@ jobs:
         id: build_vars
         run: |
           echo "APP_BUILD=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "APP_BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
-          echo "Build info: $(git rev-parse --short HEAD) at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "APP_BUILD_DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_OUTPUT
+          echo "Build info: $(git rev-parse --short HEAD) at $(date -u +"%Y-%m-%d")"
 
       - name: Deploy app
         run: |
@@ -37,8 +37,6 @@ jobs:
             --build-arg APP_BUILD=${{ steps.build_vars.outputs.APP_BUILD }} \
             --build-arg APP_BUILD_DATE=${{ steps.build_vars.outputs.APP_BUILD_DATE }}
 
-#      - name: Deploy app
-#        run: flyctl deploy --remote-only -a whereis-api-v0
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -24,8 +24,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Set build variables
+        id: build_vars
+        run: |
+          echo "APP_BUILD=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "APP_BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "Build info: $(git rev-parse --short HEAD) at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
       - name: Deploy app
-        run: flyctl deploy --remote-only -a whereis-api-v0
+        run: |
+          flyctl deploy --remote-only -a whereis-api-v0 \
+            --build-arg APP_BUILD=${{ steps.build_vars.outputs.APP_BUILD }} \
+            --build-arg APP_BUILD_DATE=${{ steps.build_vars.outputs.APP_BUILD_DATE }}
+
+#      - name: Deploy app
+#        run: flyctl deploy --remote-only -a whereis-api-v0
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,21 @@ RUN <<CMD
 set -e  # Exit on any error
 set -u  # Exit on undefined variables
 set -x  # Print commands as they execute
-deno update
+# deno update
 deno cache src/main/main.ts
 deno check .
 deno lint
 CMD
 
 ENV PORT=8037
+
+# Accept build argument
+ARG APP_BUILD=unknown
+ARG APP_BUILD_DATE=unknown
+
+# Set as environment variable
+ENV APP_BUILD=${APP_BUILD}
+ENV APP_BUILD_DATE=${APP_BUILD_DATE}
 
 # Run the app with specified permissions
 CMD ["run", "--allow-run", "--allow-net", "--allow-env", "--allow-read", "src/main/main.ts"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ IMAGE      := local/$(IMAGE_NAME):$(IMAGE_TAG)
 
 # Database type: 'sqlite' (default) or 'postgres'. Controls DB initialization.
 DB_TYPE ?= sqlite
+APP_BUILD := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+APP_BUILD_DATE := $(shell date -u +"%Y-%m-%d")
 
 # Determine which compose file to use
 ifeq ($(DB_TYPE),postgres)
@@ -97,7 +99,7 @@ init_db: check_docker config/create-whereis-db.sql # -- Initialize the postgres 
 
 build: check_docker Dockerfile docker-compose.yaml ## Build whereis-api docker image
 	@echo "=> Building Docker image with tag: $(IMAGE) for DB_TYPE=$(DB_TYPE)"
-	@docker build -t $(IMAGE) .
+	@docker build --build-arg APP_BUILD=$(APP_BUILD) --build-arg APP_BUILD_DATE=$(APP_BUILD_DATE) -t $(IMAGE) .
 
 start: check_docker ## Start api and postgres services
 	@echo "=> Starting services for DB_TYPE=$(DB_TYPE) using $(COMPOSE_FILE)..."
@@ -106,7 +108,7 @@ start: check_docker ## Start api and postgres services
 
 update: build ## Build whereis-api docker image and restart api and postgres services
 	@echo "=> Restarting services for DB_TYPE=$(DB_TYPE) using $(COMPOSE_FILE)..."
-	@docker compose -f $(COMPOSE_FILE) up $(COMPOSE_SERVICES) -d
+	@APP_BUILD=$(APP_BUILD) APP_BUILD_DATE=$(APP_BUILD_DATE) docker compose -f $(COMPOSE_FILE) up $(COMPOSE_SERVICES) -d
 	@$(MAKE) status
 
 test: check_docker ## Run 'deno task test' in the api container

--- a/config/Dockerfile.sample
+++ b/config/Dockerfile.sample
@@ -15,13 +15,21 @@ RUN <<CMD
 set -e  # Exit on any error
 set -u  # Exit on undefined variables
 set -x  # Print commands as they execute
-deno update
+# deno update
 deno cache src/main/main.ts
 deno check .
 deno lint
 CMD
 
 ENV PORT=8037
+
+# Accept build argument
+ARG APP_BUILD=unknown
+ARG APP_BUILD_DATE=unknown
+
+# Set as environment variable
+ENV APP_BUILD=${APP_BUILD}
+ENV APP_BUILD_DATE=${APP_BUILD_DATE}
 
 # Run the app with specified permissions
 CMD ["run", "--allow-run", "--allow-net", "--allow-env", "--allow-read", "src/main/main.ts"]

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,5 @@
 {
   "version": "0.3.0-alpha.1",
-  "buildDate": "2026-03-25",
   "unstable": ["cron"],
   "tasks": {
     "check": "deno lint && deno check .",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -28,7 +28,7 @@ import {initConnection} from "../db/dbutil.ts";
 export async function initApp(): Promise<void> {
   await loadEnv(); // load environment variable first
 
-  logger.info(`${whereIsAPI("startup")} Whereis API release ${Deno.env.get("APP_VERSION")}, build on ${Deno.env.get("BUILD_DATE")} (${Deno.env.get("APP_ENV")})`);
+  logger.info(`${whereIsAPI("startup")} Whereis API release ${Deno.env.get("APP_BUILD")}, build on ${Deno.env.get("APP_BUILD_DATE")} (${Deno.env.get("APP_ENV")})`);
   logger.info(`${whereIsAPI("startup")} deno ${Deno.version.deno}, setting: ${navigator.hardwareConcurrency} threads.`);
 
   await loadMetaData(); // load file system data
@@ -48,9 +48,6 @@ export async function loadEnv(): Promise<void> {
     const denoJson = JSON.parse(await Deno.readTextFile("deno.json"));
     if (denoJson.version) {
       Deno.env.set("APP_VERSION", denoJson.version);
-    }
-    if (denoJson.buildDate) {
-      Deno.env.set("BUILD_DATE", denoJson.buildDate);
     }
   } catch (_err) {
     // The deno.json file may not exist.

--- a/src/tools/version.ts
+++ b/src/tools/version.ts
@@ -14,11 +14,10 @@ async function main(): Promise<void> {
 
   // step 2: Print the application version & build date
   const appVersion = Deno.env.get("APP_VERSION");
-  const buildDate = Deno.env.get("BUILD_DATE");
-  if (!appVersion || !buildDate) {
-    throw new Error("Missing APP_VERSION or BUILD_DATE");
+  if (!appVersion) {
+    throw new Error("Missing APP_VERSION");
   }
-  console.log(`whereis-api ${appVersion} build on ${buildDate}`);
+  console.log(`whereis-api ${appVersion}`);
 
   Deno.exit(0);
 }

--- a/src/tools/version.ts
+++ b/src/tools/version.ts
@@ -12,7 +12,7 @@ async function main(): Promise<void> {
   // step 1: load environment variable first
   await loadEnv();
 
-  // step 2: Print the application version & build date
+  // step 2: Print the application version
   const appVersion = Deno.env.get("APP_VERSION");
   if (!appVersion) {
     throw new Error("Missing APP_VERSION");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build and deploy now capture and bake build metadata (Git commit SHA and UTC build date) into releases so runtime reflects exact build info.
  * Startup logging and version display simplified to show the application version and build metadata more consistently.
  * Streamlined build process by removing a redundant update step and propagating build metadata through build/update commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->