### PR TITLE
Bugfix: Make the example in the OpenAPI documentation consistent (#493)

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -175,9 +175,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/PushResponse"
               example:
-                eventsReceived: 5
-                eventsAdded: 3
-                eventsDuplicate: 2
+                eventsReceived: 2
+                eventsAdded: 1
+                eventsDuplicate: 1
                 createdTrackingIds: ['eg1-123412341234']
                 updatedTrackingIds: []
                 unchangedTrackingIds: ['eg1-567856785678']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example payload values in the push operator API documentation to reflect adjusted event counts in sample responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->